### PR TITLE
Added function to get all sample type cmbinations for each run

### DIFF
--- a/hydra_genetics/utils/units.py
+++ b/hydra_genetics/utils/units.py
@@ -113,3 +113,19 @@ def get_unit_types(units: pandas.DataFrame, sample: str) -> set[str]:
         raises an exception (KeyError) if no unit(s) can be extracted from the Dataframe
     """
     return set([u.type for u in units.loc[(sample,)].dropna().itertuples()])
+
+
+def get_units_per_run(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards):
+    """
+    function used to extract all sample and type combinations for one sequencing run
+    Args:
+        units: DataFrame generate by importing a file following schema defintion
+               found in pre-alignment/workflow/schemas/units.schema.tsv
+        wildcards: wildcards object with at least the following wildcard names
+               sample, run.
+    Returns:
+        tuple with sample and type
+    Raises:
+        raises an exception (KeyError) if no unit(s) can be extracted from the Dataframe
+    """
+    return set([(u.sample, u.type) for u in units[units.run == wildcards.run].itertuples()])

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -302,3 +302,14 @@ class TestUnitUtils(unittest.TestCase):
             get_unit_types(self.units, Wildcards(fromdict={'sample': 'BE12878'})),
             {'N', 'T', 'R'}
         )
+
+    def test_get_units_per_run(self):
+        from hydra_genetics.utils.units import get_units_per_run
+        self.assertEqual(
+            len(get_units_per_run(self.units, Wildcards(fromdict={"run": "1"}))),
+            4
+        )
+        self.assertEqual(
+            len(get_units_per_run(self.units, Wildcards(fromdict={"run": "2"}))),
+            3
+        )


### PR DESCRIPTION
### This PR:

### Review and tests: 
- [x] Tests pass
- [x] New code is executed and covered by tests, and test approve
